### PR TITLE
Security fix: do not log password

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -66,14 +66,8 @@ class Chef
               password = "'#{@new_resource.password}'"
               filtered = '[FILTERED]'
             end
-            grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON #{@new_resource.database_name ? "`#{@new_resource.database_name}`" : '*'}.#{@new_resource.table ? "`#{@new_resource.table}`" : '*'} TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY "
-            grant_statement += password
-
-            if (@new_resource.require_ssl) then
-              grant_statement += " REQUIRE SSL"
-            end
-            Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}#{filtered}]")
-            db.query(grant_statement)
+            Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement(filtered)}]")
+            db.query(grant_statement(password))
             @new_resource.updated_by_last_action(true)
           ensure
             close
@@ -81,8 +75,17 @@ class Chef
         end
 
         private
+
         def exists?
           db.query("SELECT User,host from mysql.user WHERE User = '#{@new_resource.username}' AND host = '#{@new_resource.host}'").num_rows != 0
+        end
+
+        def grant_statement(password)
+          grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON #{@new_resource.database_name ? "`#{@new_resource.database_name}`" : '*'}.#{@new_resource.table ? "`#{@new_resource.table}`" : '*'} TO `#{@new_resource.username}`@`#{@new_resource.host}` IDENTIFIED BY #{password}"
+          if @new_resource.require_ssl then
+            grant_statement += ' REQUIRE SSL'
+          end
+          grant_statement
         end
       end
     end


### PR DESCRIPTION
Don't log the password when granting access to a MySQL user using the `database_mysql_user` resource.
This security issue seems to have existed since [PR 62](https://github.com/opscode-cookbooks/database/pull/62/files)
