### PR TITLE
Grant permissions on selected tables, sequences and functions inside a postgresql schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,12 +366,16 @@ Manage users and user privileges in a RDBMS. Use the proper shortcut resource de
       action :grant
     end
 
-    # grant all privileges on all tables in foo db
+    # grant all privileges on all tables, sequences and functions in public schema of foo db
     postgresql_database_user 'foo_user' do
       connection postgresql_connection_info
       database_name 'foo'
+      schema_name 'public'
+      tables [:all]
+      sequences [:all]
+      functions [:all]
       privileges [:all]
-      action :grant
+      action [ :grant, :grant_schema, :grant_table, :grant_sequence, :grant_function ]
     end
 
     # grant select,update,insert privileges to all tables in foo db

--- a/libraries/provider_database_postgresql_user.rb
+++ b/libraries/provider_database_postgresql_user.rb
@@ -85,6 +85,51 @@ class Chef
           close
         end
 
+        def action_grant_table
+          grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON "
+          if @new_resource.tables.include?(:all)
+            grant_statement << "ALL TABLES IN SCHEMA \"#{@new_resource.schema_name}\""
+          else
+            grant_statement << "TABLE #{@new_resource.tables.join(', ')}"
+          end
+          grant_statement << " TO \"#{@new_resource.username}\""
+          Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}]")
+          db(@new_resource.database_name).query(grant_statement)
+          @new_resource.updated_by_last_action(true)
+        ensure
+          close
+        end
+
+        def action_grant_sequence
+          grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON "
+          if @new_resource.sequences.include?(:all)
+            grant_statement << "ALL SEQUENCES IN SCHEMA \"#{@new_resource.schema_name}\""
+          else
+            grant_statement << "SEQUENCE #{@new_resource.sequences.join(', ')}"
+          end
+          grant_statement << " TO \"#{@new_resource.username}\""
+          Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}]")
+          db(@new_resource.database_name).query(grant_statement)
+          @new_resource.updated_by_last_action(true)
+        ensure
+          close
+        end
+
+        def action_grant_function
+          grant_statement = "GRANT #{@new_resource.privileges.join(', ')} ON "
+          if @new_resource.functions.include?(:all)
+            grant_statement << "ALL FUNCTIONS IN SCHEMA \"#{@new_resource.schema_name}\""
+          else
+            grant_statement << "FUNCTION #{@new_resource.functions.join(', ')}"
+          end
+          grant_statement << " TO \"#{@new_resource.username}\""
+          Chef::Log.info("#{@new_resource}: granting access with statement [#{grant_statement}]")
+          db(@new_resource.database_name).query(grant_statement)
+          @new_resource.updated_by_last_action(true)
+        ensure
+          close
+        end
+
         private
 
         def exists?

--- a/libraries/resource_postgresql_database_user.rb
+++ b/libraries/resource_postgresql_database_user.rb
@@ -34,7 +34,10 @@ class Chef
         @replication = false
         @superuser = false
         @schema_name = nil
-        @allowed_actions.push(:create, :drop, :grant, :grant_schema)
+        @tables = [:all]
+        @sequences = [:all]
+        @functions = [:all]
+        @allowed_actions.push(:create, :drop, :grant, :grant_schema, :grant_table, :grant_sequence, :grant_function)
       end
 
       def createdb(arg = nil)
@@ -82,6 +85,30 @@ class Chef
           :superuser,
           arg,
           equal_to: [true, false]
+        )
+      end
+
+      def tables(arg = nil)
+        set_or_return(
+          :tables,
+          arg,
+          kind_of: Array, default: [:all]
+        )
+      end
+
+      def sequences(arg = nil)
+        set_or_return(
+          :sequences,
+          arg,
+          kind_of: Array, default: [:all]
+        )
+      end
+
+      def functions(arg = nil)
+        set_or_return(
+          :functions,
+          arg,
+          kind_of: Array, default: [:all]
         )
       end
     end

--- a/test/fixtures/cookbooks/postgresql_database_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/postgresql_database_test/recipes/default.rb
@@ -32,7 +32,15 @@ end
 ## resources we're testing
 postgresql_database 'dataflounder' do
   connection connection_info
-  action :create
+  database_name 'dataflounder'
+  sql <<-EOF
+    CREATE TABLE IF NOT EXISTS person (
+      uid serial PRIMARY KEY,
+      firstname varchar(50)  NULL CHECK (firstname <> ''),
+      lastname varchar(50) NOT NULL CHECK (lastname <> '')
+    );
+  EOF
+  action [:create, :query]
 end
 
 postgresql_database 'datacarp' do
@@ -46,6 +54,15 @@ postgresql_database_user 'animal' do
   superuser true
   login true
   action :create
+end
+
+postgresql_database_user 'human' do
+  connection connection_info
+  password 'raaaaaaaaaaaaaaaaaaaaaaaaaaaaah'
+  login true
+  database_name 'dataflounder'
+  schema_name 'public'
+  action [:create, :grant, :grant_schema]
 end
 
 postgresql_database_user 'gonzo' do

--- a/test/integration/default/serverspec/postgresql_spec.rb
+++ b/test/integration/default/serverspec/postgresql_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
 psql = 'env PGPASSWORD=raaaaaaaaaaaaaaaaaaaaaaaaaaaaah psql -h 127.0.0.1 -U animal -d postgres'
+psql_user = 'env PGPASSWORD=raaaaaaaaaaaaaaaaaaaaaaaaaaaaah psql -h 127.0.0.1 -U human -d dataflounder'
 
 describe('postgresql_database_test::default') do
+  # check that superuser has access to the test database
   describe command("#{psql} -c 'SELECT * from pg_database;' | grep dataflounder") do
+    its(:exit_status) { should eq 0 }
+  end
+
+  # check grants from normal user on test database and schema
+  describe command("#{psql_user} -c '\\dt' | grep person") do
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
The current `database_postgresql_user` resource can only set perms at the database and schema levels which is not enough to replicate the flexibility and complexity of the [GRANT command](http://www.postgresql.org/docs/9.3/static/sql-grant.html) in PostgreSQL.

So I've added actions and attributes for granting perms on some or all tables, sequences and functions in a schema:
```ruby
    # grant all privileges on all tables, sequences and functions in public schema of foo db
    postgresql_database_user 'foo_user' do
      connection postgresql_connection_info
      database_name 'foo'
      schema_name 'public'
      tables [:all]
      sequences [:all]
      functions [:all]
      privileges [:all]
      action [:grant, :grant_schema, :grant_table, :grant_sequence, :grant_function]
    end ```