### PR TITLE
Allow to use hashed password string with mysql_database_user LWRP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,17 @@ mysql_database_user 'foo_user' do
   action        :grant
 end
 
+# The same as above but utilizing hased password string instead of
+# plain text one
+mysql_database_user 'foo_user' do
+  connection    mysql_connection_info
+  password      mysql_hashed_password('*664E8D709A6EBADFC68361EBE82CF77F10211E52')
+  database_name 'foo'
+  host          '%'
+  privileges    [:select,:update,:insert]
+  action        :grant
+end
+
 # Grant all privileges on all databases/tables from 127.0.0.1
 mysql_database_user 'super_user' do
   connection mysql_connection_info

--- a/libraries/mysql_password.rb
+++ b/libraries/mysql_password.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Maksim Horbul (<max@gorbul.net>)
+# Cookbook Name:: database
+# Library:: mysql_password
+#
+# Copyright:: 2016 Eligible, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.join(File.dirname(__FILE__), 'resource_mysql_database_user')
+
+class MysqlPassword
+
+  # Initializes an object of the MysqlPassword type
+  # @param [String] hashed_password mysql native hashed password
+  # @return [MysqlPassword]
+  def initialize(hashed_password)
+    @hashed_password = hashed_password
+  end
+
+  # String representation of the object
+  # @return [String] hashed password string
+  def to_s
+    @hashed_password
+  end
+
+  module Helpers
+
+    # helper method wrappers the string into a MysqlPassword object
+    # @param [String] hashed_password mysql native hashed password
+    # @return [MysqlPassword] object
+    def mysql_hashed_password(hashed_password)
+      MysqlPassword.new hashed_password
+    end
+  end
+end
+
+::Chef::Resource::MysqlDatabaseUser.send(:include, MysqlPassword::Helpers)

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -125,7 +125,11 @@ class Chef
                 repair_sql = "GRANT #{new_resource.privileges.join(',')}"
                 repair_sql += " ON #{db_name}.#{tbl_name}"
                 repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
-                repair_sql += " '#{new_resource.password}'"
+                if new_resource.password.is_a?(MysqlPassword)
+                  repair_sql += " PASSWORD '#{new_resource.password}'"
+                else
+                  repair_sql += " '#{new_resource.password}'"
+                end
                 repair_sql += ' REQUIRE SSL' if new_resource.require_ssl
                 repair_sql += ' WITH GRANT OPTION' if new_resource.grant_option
 

--- a/libraries/resource_database_user.rb
+++ b/libraries/resource_database_user.rb
@@ -61,14 +61,6 @@ class Chef
         )
       end
 
-      def password(arg = nil)
-        set_or_return(
-          :password,
-          arg,
-          kind_of: String
-        )
-      end
-
       def table(arg = nil)
         set_or_return(
           :table,

--- a/libraries/resource_mysql_database_user.rb
+++ b/libraries/resource_mysql_database_user.rb
@@ -27,6 +27,15 @@ class Chef
         @resource_name = :mysql_database_user
         @provider = Chef::Provider::Database::MysqlUser
       end
+
+      def password(arg = nil)
+        set_or_return(
+          :password,
+          arg,
+          kind_of: [String, MysqlPassword]
+        )
+      end
+
     end
   end
 end

--- a/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
@@ -70,6 +70,16 @@ mysql_database_user 'fozzie' do
   action :grant
 end
 
+mysql_database_user 'moozie' do
+  connection connection_info
+  database_name 'databass'
+  password mysql_hashed_password('*F798E7C0681068BAE3242AA2297D2360DBBDA62B')
+  host '127.0.0.1'
+  privileges [:select, :update, :insert]
+  require_ssl false
+  action :grant
+end
+
 mysql_database 'flush repl privileges' do
   connection connection_info
   database_name 'databass'

--- a/test/integration/mysql/serverspec/mysql_spec.rb
+++ b/test/integration/mysql/serverspec/mysql_spec.rb
@@ -16,4 +16,16 @@ describe('mysql_database_test::default') do
   describe command("echo 'select User,Host from mysql.user;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3 | grep kermit") do
     its(:exit_status) { should eq 1 }
   end
+
+  describe command("echo 'select Password from mysql.user where User like \"fozzie\" \\G;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3") do
+    its(:stdout) { should contain /Password: \*EF112B3D562CB63EA3275593C10501B59C4A390D/ }
+  end
+
+  describe command("echo 'select Password from mysql.user where User like \"moozie\" \\G;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3") do
+    its(:stdout) { should contain /Password: \*F798E7C0681068BAE3242AA2297D2360DBBDA62B/ }
+  end
+
+  describe command("echo 'show tables;' | /usr/bin/mysql -u moozie -h 127.0.0.1 -P 3306 -pzokkazokka databass") do
+    its(:exit_status) { should eq 0 }
+  end
 end


### PR DESCRIPTION
This change makes `mysql_database_user` resource more flexible and allow to avoid using plain text passwords in the recipes. Instead, a developer can provide MySQL hashed strings utilizing helper method.