### PR TITLE
Update user passwords on change in :create and :grant

### DIFF
--- a/test/integration/mysql/serverspec/mysql_spec.rb
+++ b/test/integration/mysql/serverspec/mysql_spec.rb
@@ -28,4 +28,16 @@ describe('mysql_database_test::default') do
   describe command("echo 'show tables;' | /usr/bin/mysql -u moozie -h 127.0.0.1 -P 3306 -pzokkazokka databass") do
     its(:exit_status) { should eq 0 }
   end
+
+  describe command("echo 'select Password from mysql.user where User like \"rowlf\" \\G;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3") do
+    its(:stdout) { should contain /Password: \*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9/ }
+  end
+
+  describe command("echo 'select Password from mysql.user where User like \"statler\" \\G;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3") do
+    its(:stdout) { should contain /Password: \*2027D9391E714343187E07ACB41AE8925F30737E/ }
+  end
+
+  describe command("echo 'select Password from mysql.user where User like \"rizzo\" \\G;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -pub3rs3kur3") do
+    its(:stdout) { should contain /Password: \*125EA03B506F7C876D9321E9055F37601461E970/ }
+  end
 end


### PR DESCRIPTION
This addresses https://github.com/chef-cookbooks/database/issues/164,
which bit us as well. Noting https://github.com/chef-cookbooks/database/pull/165,
this includes code that should function correctly in 5.7.

I did not see a Test Kitchen environment that verifies 5.7 functionality and spent
more than an hour trying to make debian-7.9 switch to 5.7, without success. If there
is a current Test Kitchen environment that will test 5.7 I will gladly run it.

The current test suite bails in fedora-23 on my machine; my guess to the cause
would be it apparently dropped support for mysql in favor of mariadb.