### PR TITLE
Fix 'already initialized constant' warnings while testing

### DIFF
--- a/libraries/resource_postgresql_database_user.rb
+++ b/libraries/resource_postgresql_database_user.rb
@@ -24,11 +24,11 @@ require File.join(File.dirname(__FILE__), 'provider_database_postgresql_user')
 class Chef
   class Resource
     class PostgresqlDatabaseUser < Chef::Resource::DatabaseUser
-      CREATE_DB_DEFAULT = false
-      CREATE_ROLE_DEFAULT = false
-      LOGIN_DEFAULT = true
-      REPLICATION_DEFAULT = false
-      SUPERUSER_DEFAULT = false
+      CREATE_DB_DEFAULT = false unless defined?(CREATE_DB_DEFAULT)
+      CREATE_ROLE_DEFAULT = false unless defined?(CREATE_ROLE_DEFAULT)
+      LOGIN_DEFAULT = true unless defined?(LOGIN_DEFAULT)
+      REPLICATION_DEFAULT = false unless defined?(REPLICATION_DEFAULT)
+      SUPERUSER_DEFAULT = false unless defined?(SUPERUSER_DEFAULT)
 
       def initialize(name, run_context = nil)
         super


### PR DESCRIPTION
Fix ruby warnings when testing multiple postgresql_database_user
resource calls in single recipe.

When testing (ChefSpec) multiple database resources in single recipe, I've encountered warning about constants re-initialization:

```
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:27: warning: already initialized constant Chef::Resource::PostgresqlDatabaseUser::CREATE_DB_DEFAULT
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:27: warning: previous definition of CREATE_DB_DEFAULT was here
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:28: warning: already initialized constant Chef::Resource::PostgresqlDatabaseUser::CREATE_ROLE_DEFAULT
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:28: warning: previous definition of CREATE_ROLE_DEFAULT was here
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:29: warning: already initialized constant Chef::Resource::PostgresqlDatabaseUser::LOGIN_DEFAULT
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:29: warning: previous definition of LOGIN_DEFAULT was here
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:30: warning: already initialized constant Chef::Resource::PostgresqlDatabaseUser::REPLICATION_DEFAULT
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:30: warning: previous definition of REPLICATION_DEFAULT was here
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:31: warning: already initialized constant Chef::Resource::PostgresqlDatabaseUser::SUPERUSER_DEFAULT
/home/szymon/ragnarson/chef/site-cookbooks/database/libraries/resource_postgresql_database_user.rb:31: warning: previous definition of SUPERUSER_DEFAULT was here
```

I don't think we can fix this 'chef-way', by using [:default](http://www.rubydoc.info/gems/chef/12.7.2/Chef/Mixin/ParamsValidate) validator in each `set_or_return` [call](https://github.com/chef-cookbooks/database/blob/master/libraries/resource_postgresql_database_user.rb#L50) and then drop setting defaults for [non-postgresql-database-user-call](https://github.com/chef-cookbooks/database/blob/master/libraries/provider_database_postgresql_user.rb#L55-L60).

It's only 'sane' solution I was able to came up with.