### PR TITLE
Fix for Unknown column 'mysql_native_password' error

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -318,7 +318,7 @@ class Chef
           else
             test_sql = 'SELECT User,Host,authentication_string FROM mysql.user ' \
                        "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' " \
-                       'AND plugin=mysql_native_password '
+                       "AND plugin='mysql_native_password' "
             test_sql += if new_resource.password.is_a? MysqlPassword
                           "AND authentication_string='#{new_resource.password}'"
                         else


### PR DESCRIPTION
### Description

Fixes the Unknown column 'mysql_native_password' error I get on chef runs for action :create on a user that exists.

### Issues Resolved

/ No issue opened.

### Check List
- [X ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [ X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


When I use the default version of the cookbook, i get this error:
Mysql2::Error
==> jenkins:
==> jenkins:     -------------
==> jenkins:     Unknown column 'mysql_native_password' in 'where clause'
==> jenkins:
==> jenkins:     Cookbook Trace:
==> jenkins:     ---------------
==> jenkins:     /var/chef/cache/cookbooks/database/libraries/provider_database_mysql_user.rb:328:in `test_user_password'
==> jenkins:     /var/chef/cache/cookbooks/database/libraries/provider_database_mysql_user.rb:42:in `block in <class:MysqlUser>'

Adding quotes around the value, fixes this.