### PR TITLE
Add require_x509 option for mysql grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Manage users and user privileges in a RDBMS. Use the proper shortcut resource de
 - table: table to grant privileges on. used by :grant action and MySQL
   provider only. default is '*' (all tables)
 - require_ssl: true or false to force SSL connections to be used for user
+- require_x509: true or false to force SSL with client certificate verification
 
 #### Providers
 - `Chef::Provider::Database::MysqlUser`: shortcut resource `mysql_database_user`

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -137,6 +137,7 @@ class Chef
                                 " '#{new_resource.password}'"
                               end
                 repair_sql += ' REQUIRE SSL' if new_resource.require_ssl
+                repair_sql += ' REQUIRE X509' if new_resource.require_x509
                 repair_sql += ' WITH GRANT OPTION' if new_resource.grant_option
 
                 Chef::Log.info("#{@new_resource}: granting with sql [#{repair_sql}]")

--- a/libraries/resource_database_user.rb
+++ b/libraries/resource_database_user.rb
@@ -32,6 +32,7 @@ class Chef
         @privileges = [:all]
         @grant_option = false
         @require_ssl = false
+        @require_x509 = false
 
         @allowed_actions.push(:create, :drop, :grant, :revoke)
         @action = :create
@@ -56,6 +57,14 @@ class Chef
       def require_ssl(arg = nil)
         set_or_return(
           :require_ssl,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def require_x509(arg = nil)
+        set_or_return(
+          :require_x509,
           arg,
           kind_of: [TrueClass, FalseClass]
         )


### PR DESCRIPTION
This adds an option to include 'REQUIRE X509' in user grants in MySQL. It's identical to require_ssl but has the added effect of requiring client certificate verification for the user.