### PR TITLE
Support reading of options from my.cnf for MySQL, fix hashed_password for CREATE USER and fix rubocop introduced bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ depending on your RDBMS: `mysql_database`, `postgresql_database`,
 - database_name: name attribute. Name of the database to interact with
 - connection: hash of connection info. valid keys include `:host`,
   `:port`, `:username`, and `:password`
-    - only for MySQL DB*: `:flags` (see `Mysql2::Client@@default_query_options[:connect_flags]`)
+    - only for MySQL DB*:
+      - `:flags` (see `Mysql2::Client@@default_query_options[:connect_flags]`)
+      - `:default_file`, `:default_group` (see https://github.com/brianmario/mysql2#reading-a-mysql-config-file)
     - only for PostgreSQL: `:database` (overwrites parameter `database_name`)
     - not used for SQLlite
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,14 @@ postgresql_database_user 'disenfranchised' do
   action     :create
 end
 
+# The same as above but utilizing hashed password string instead of
+# plain text one
+postgresql_database_user 'disenfranchised' do
+  connection    postgresql_connection_info
+  password      hashed_password('md5eacdbf8d9847a76978bd515fae200a2a')
+  action        :grant
+end
+
 # Do the same but pass the provider to the database resource
 database_user 'disenfranchised' do
   connection postgresql_connection_info
@@ -386,11 +394,11 @@ mysql_database_user 'foo_user' do
   action        :grant
 end
 
-# The same as above but utilizing hased password string instead of
+# The same as above but utilizing hashed password string instead of
 # plain text one
 mysql_database_user 'foo_user' do
   connection    mysql_connection_info
-  password      mysql_hashed_password('*664E8D709A6EBADFC68361EBE82CF77F10211E52')
+  password      hashed_password('*664E8D709A6EBADFC68361EBE82CF77F10211E52')
   database_name 'foo'
   host          '%'
   privileges    [:select,:update,:insert]

--- a/libraries/hashed_password.rb
+++ b/libraries/hashed_password.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Maksim Horbul (<max@gorbul.net>)
 # Cookbook Name:: database
-# Library:: mysql_password
+# Library:: hashed_password
 #
 # Copyright:: 2016 Eligible, Inc.
 #
@@ -18,8 +18,9 @@
 # limitations under the License.
 
 require File.join(File.dirname(__FILE__), 'resource_mysql_database_user')
+require File.join(File.dirname(__FILE__), 'resource_postgresql_database_user')
 
-class MysqlPassword
+class HashedPassword
   # Initializes an object of the MysqlPassword type
   # @param [String] hashed_password mysql native hashed password
   # @return [MysqlPassword]
@@ -37,10 +38,13 @@ class MysqlPassword
     # helper method wrappers the string into a MysqlPassword object
     # @param [String] hashed_password mysql native hashed password
     # @return [MysqlPassword] object
-    def mysql_hashed_password(hashed_password)
-      MysqlPassword.new hashed_password
+    def hashed_password(hashed_password)
+      HashedPassword.new hashed_password
     end
+    # For backward compatibility, because method was renamed
+    alias_method :mysql_hashed_password, :hashed_password
   end
 end
 
-::Chef::Resource::MysqlDatabaseUser.send(:include, MysqlPassword::Helpers)
+::Chef::Resource::MysqlDatabaseUser.send(:include, HashedPassword::Helpers)
+::Chef::Resource::PostgresqlDatabaseUser.send(:include, HashedPassword::Helpers)

--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -107,7 +107,9 @@ class Chef
               socket: new_resource.connection[:socket],
               username: new_resource.connection[:username],
               password: new_resource.connection[:password],
-              port: new_resource.connection[:port]
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
             )
         end
 
@@ -125,7 +127,9 @@ class Chef
               socket: new_resource.connection[:socket],
               username: new_resource.connection[:username],
               password: new_resource.connection[:password],
-              port: new_resource.connection[:port]
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
             )
         end
 
@@ -144,6 +148,8 @@ class Chef
               username: new_resource.connection[:username],
               password: new_resource.connection[:password],
               port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group],
               flags: new_resource.connection[:flags],
               database: new_resource.database_name
             )

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -49,7 +49,14 @@ class Chef
             converge_by "Creating user '#{new_resource.username}'@'#{new_resource.host}'" do
               begin
                 repair_sql = "CREATE USER '#{new_resource.username}'@'#{new_resource.host}'"
-                repair_sql += " IDENTIFIED BY '#{new_resource.password}'" if new_resource.password
+                if new_resource.password
+                  repair_sql += ' IDENTIFIED BY '
+                  repair_sql += if new_resource.password.is_a?(MysqlPassword)
+                                  " PASSWORD '#{new_resource.password}'"
+                                else
+                                  " '#{new_resource.password}'"
+                                end
+                end
                 repair_client.query(repair_sql)
               ensure
                 close_repair_client

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -116,7 +116,7 @@ class Chef
             test_sql += " AND Db='#{new_resource.database_name}'" if new_resource.database_name
             test_sql_results = test_client.query test_sql
 
-            incorrect_privs = true if test_sql_results.empty?
+            incorrect_privs = true if test_sql_results.size == 0
             # These should all be 'Y'
             test_sql_results.each do |r|
               desired_privs.each do |p|
@@ -336,7 +336,7 @@ class Chef
                           "AND authentication_string=PASSWORD('#{new_resource.password}')"
                         end
           end
-          !test_client.query(test_sql).empty?
+          test_client.query(test_sql).size > 0
         end
 
         def update_user_password
@@ -367,7 +367,7 @@ class Chef
         end
 
         def database_has_password_column(client)
-          !client.query('SHOW COLUMNS FROM mysql.user WHERE Field="Password"').empty?
+          client.query('SHOW COLUMNS FROM mysql.user WHERE Field="Password"').size > 0
         end
       end
     end

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -51,7 +51,7 @@ class Chef
                 repair_sql = "CREATE USER '#{new_resource.username}'@'#{new_resource.host}'"
                 if new_resource.password
                   repair_sql += ' IDENTIFIED BY '
-                  repair_sql += if new_resource.password.is_a?(MysqlPassword)
+                  repair_sql += if new_resource.password.is_a?(HashedPassword)
                                   " PASSWORD '#{new_resource.password}'"
                                 else
                                   " '#{new_resource.password}'"
@@ -138,7 +138,7 @@ class Chef
                 repair_sql = "GRANT #{new_resource.privileges.join(',')}"
                 repair_sql += " ON #{db_name}.#{tbl_name}"
                 repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
-                repair_sql += if new_resource.password.is_a?(MysqlPassword)
+                repair_sql += if new_resource.password.is_a?(HashedPassword)
                                 " PASSWORD '#{new_resource.password}'"
                               else
                                 " '#{new_resource.password}'"
@@ -321,7 +321,7 @@ class Chef
           if database_has_password_column(test_client)
             test_sql = 'SELECT User,Host,Password FROM mysql.user ' \
                        "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' "
-            test_sql += if new_resource.password.is_a? MysqlPassword
+            test_sql += if new_resource.password.is_a? HashedPassword
                           "AND Password='#{new_resource.password}'"
                         else
                           "AND Password=PASSWORD('#{new_resource.password}')"
@@ -330,7 +330,7 @@ class Chef
             test_sql = 'SELECT User,Host,authentication_string FROM mysql.user ' \
                        "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' " \
                        "AND plugin='mysql_native_password' "
-            test_sql += if new_resource.password.is_a? MysqlPassword
+            test_sql += if new_resource.password.is_a? HashedPassword
                           "AND authentication_string='#{new_resource.password}'"
                         else
                           "AND authentication_string=PASSWORD('#{new_resource.password}')"
@@ -344,7 +344,7 @@ class Chef
             begin
               if database_has_password_column(repair_client)
                 repair_sql = "SET PASSWORD FOR '#{new_resource.username}'@'#{new_resource.host}' = "
-                repair_sql += if new_resource.password.is_a? MysqlPassword
+                repair_sql += if new_resource.password.is_a? HashedPassword
                                 "'#{new_resource.password}'"
                               else
                                 " PASSWORD('#{new_resource.password}')"
@@ -353,7 +353,7 @@ class Chef
                 # "ALTER USER is now the preferred statement for assigning passwords."
                 # http://dev.mysql.com/doc/refman/5.7/en/set-password.html
                 repair_sql = "ALTER USER '#{new_resource.username}'@'#{new_resource.host}' "
-                repair_sql += if new_resource.password.is_a? MysqlPassword
+                repair_sql += if new_resource.password.is_a? HashedPassword
                                 "IDENTIFIED WITH mysql_native_password AS '#{new_resource.password}'"
                               else
                                 "IDENTIFIED BY '#{new_resource.password}'"

--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -268,7 +268,9 @@ class Chef
               socket: new_resource.connection[:socket],
               username: new_resource.connection[:username],
               password: new_resource.connection[:password],
-              port: new_resource.connection[:port]
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
             )
         end
 
@@ -286,7 +288,9 @@ class Chef
               socket: new_resource.connection[:socket],
               username: new_resource.connection[:username],
               password: new_resource.connection[:password],
-              port: new_resource.connection[:port]
+              port: new_resource.connection[:port],
+              default_file: new_resource.connection[:default_file],
+              default_group: new_resource.connection[:default_group]
             )
         end
 

--- a/libraries/resource_mysql_database_user.rb
+++ b/libraries/resource_mysql_database_user.rb
@@ -32,7 +32,7 @@ class Chef
         set_or_return(
           :password,
           arg,
-          kind_of: [String, MysqlPassword]
+          kind_of: [String, HashedPassword]
         )
       end
     end

--- a/libraries/resource_postgresql_database_user.rb
+++ b/libraries/resource_postgresql_database_user.rb
@@ -67,6 +67,14 @@ class Chef
         )
       end
 
+      def password(arg = nil)
+        set_or_return(
+          :password,
+          arg,
+          kind_of: [String, HashedPassword]
+        )
+      end
+
       def replication(arg = nil)
         set_or_return(
           :replication,

--- a/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/mysql_database_test/recipes/default.rb
@@ -108,7 +108,7 @@ end
 
 mysql_database_user 'statler' do
   connection connection_info
-  password mysql_hashed_password('*2027D9391E714343187E07ACB41AE8925F30737E'); # 'l33t'
+  password hashed_password('*2027D9391E714343187E07ACB41AE8925F30737E'); # 'l33t'
   action :create
 end
 
@@ -125,7 +125,7 @@ end
 mysql_database_user 'moozie' do
   connection connection_info
   database_name 'databass'
-  password mysql_hashed_password('*F798E7C0681068BAE3242AA2297D2360DBBDA62B')
+  password hashed_password('*F798E7C0681068BAE3242AA2297D2360DBBDA62B')
   host '127.0.0.1'
   privileges [:select, :update, :insert]
   require_ssl false


### PR DESCRIPTION
### Description

Support reading of options from my.cnf for MySQL

### Issues Resolved

Similar to: https://github.com/chef-cookbooks/database/pull/33
Fixed: https://github.com/chef-cookbooks/database/pull/193
Reverts: https://github.com/chef-cookbooks/database/commit/7531f1b02eaef44f33ef6d3d5a0fee9bc943bf45

### Check List
- [-] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [-] New functionality includes testing.
- [+] New functionality has been documented in the README if applicable
- [+] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


